### PR TITLE
Bugfix of selecting process data format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 2.1.1
+
+### Bugfixes
+- Bugfix of selecting process data format with new version of IODD interpreter
+
 ## Release 2.1.0
 
 ### New features

--- a/CSK_Module_IODDInterpreter/project.mf.xml
+++ b/CSK_Module_IODDInterpreter/project.mf.xml
@@ -475,7 +475,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">2.1.0</meta>
+        <meta key="version">2.1.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
@@ -306,7 +306,7 @@ Script.serveFunction('CSK_IODDInterpreter.deleteIODD', deleteIODD)
 ---@param selectedProcessDataTable string[] Selected process data
 local function updateSelectedProcessDataTable(selectedRow, selectedProcessDataTable)
   local state = selectedRow.selected
-  local subindex = selectedRow.colPD1
+  local subindex = tostring(selectedRow.colPD1)
   if subindex ~= "0" then
     if state == false and selectedProcessDataTable["0"] == true then
       selectedProcessDataTable["0"] = false
@@ -326,8 +326,8 @@ end
 ---@param selectedParametersTable string[] Selected parameter data
 local function updateSelectedParametersTable(selectedRow, selectedParametersTable)
   local state = selectedRow.selected
-  local index = selectedRow.colSD1
-  local subindex = selectedRow.colSD2
+  local index = tostring(selectedRow.colSD1)
+  local subindex = tostring(selectedRow.colSD2)
   if subindex ~= "0" then
     if state == false and selectedParametersTable[index]["0"] == true then
       selectedParametersTable[index]["0"] = false
@@ -352,6 +352,7 @@ local function getParameterDataPointInfo(instanceId, index, subindex)
   if not dataPointInfo then
     return nil
   end
+  dataPointInfo = {info = ioddInterpreter_Model.helperFuncs.getSingleInfoTable(dataPointInfo)}
   local jsonDataPointInfo = ioddInterpreter_Model.json.encode(dataPointInfo)
   return jsonDataPointInfo
 end

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/helper/funcs.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/helper/funcs.lua
@@ -255,6 +255,7 @@ local function getSingleInfoTable(rawInfoTable)
   info.SimpleDatatype = nil
   return info
 end
+funcs.getSingleInfoTable = getSingleInfoTable
 
 local function compileDataPointTable(dataInfo, selectedTable)
   if not dataInfo then

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Tested on
 |Device|Firmware version|Module version|
 |--|--|--|
 |SICK AppEngine|V1.7.0|V1.1.0|
+|SIM1012|V2.4.2|V2.1.1|
 |SIM1012|V2.4.2|V2.1.0|
 |SIM1012|V2.4.2|V1.1.0|
 |SIM1012|v2.3.0|v1.0.1|

--- a/docu/CSK_Module_IODDInterpreter.html
+++ b/docu/CSK_Module_IODDInterpreter.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_IODDInterpreter 2.1.0</title>
+<title>Documentation - CSK_Module_IODDInterpreter 2.1.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,10 +615,10 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_IODDInterpreter 2.1.0</h1>
+<h1>Documentation - CSK_Module_IODDInterpreter 2.1.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 2.1.0,</span>
+<span id="revnumber">version 2.1.1,</span>
 <span id="revdate">2025-01-22</span>
 </div>
 <div id="toc" class="toc2">
@@ -755,7 +755,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2.1.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2.1.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
@@ -5534,7 +5534,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 2.1.0<br>
+Version 2.1.1<br>
 Last updated 2025-01-22 11:40:09 +0100
 </div>
 </div>


### PR DESCRIPTION
# Version 2.1.1

## Bugfix

### Bugfix of selecting process data format with new version of IODD interpreter

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
