### PR TITLE
# Release 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## Release 2.1.3
 
+### Improvements
+- Check for BOM in XML file
+
 ### Bugfix
 - Legacy bindings of ValueDisplay elements and FileUpload feature within UI did not work if deployed with VS Code AppSpace SDK
 - UI differs if deployed via Appstudio or VS Code AppSpace SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 2.1.3
+
+### Bugfix
+- Legacy bindings of ValueDisplay elements and FileUpload feature within UI did not work if deployed with VS Code AppSpace SDK
+- UI differs if deployed via Appstudio or VS Code AppSpace SDK
+- Fullscreen icon of iFrame was visible
+
 ## Release 2.1.2
 
 ### Bugfixes

--- a/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter.css
+++ b/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter.css
@@ -69,5 +69,5 @@
 
 .myCustomButton_CSK_Module_IODDInterpreter {
   border-radius: 30px;
-  padding-right: 0px;
+  padding: 11px;
 }

--- a/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter.html
+++ b/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter.html
@@ -6,13 +6,12 @@
         <layout-row id="RowLayout12">
             <layout-column id="ColumnLayout2" style="align-items: stretch">
                 <layout-row id="RowLayout01" style="align-items: baseline">
-                    <davinci-value-display id="VD_Title" class="myCustomLabel_CSK_Module_IODDInterpreter"
-                        value="IODD Interpreter">
-                    </davinci-value-display>
+                    <h1 id="Heading_Title" class="myCustomLabel_CSK_Module_IODDInterpreter">
+                        IODD Interpreter
+                    </h1>
                     <davinci-value-display id="VD_Version">
-                        <crown-edpws-binding property="value" name="CSK_IODDInterpreter/OnNewStatusModuleVersion"
-                            update-on-resume>
-                        </crown-edpws-binding>
+                        <crown-on property="value" crown-event="CSK_IODDInterpreter/OnNewStatusModuleVersion">
+                        </crown-on>
                     </davinci-value-display>
                 </layout-row>
             </layout-column>
@@ -46,7 +45,8 @@
                                                             </crown-on>
                                                             <crown-set event="change"
                                                                 crown-function="CSK_IODDInterpreter/setSelectedInstance"
-                                                                protocol="crownMSGPACK" crown-path="newSelectedInstance">
+                                                                protocol="crownMSGPACK"
+                                                                crown-path="newSelectedInstance">
                                                             </crown-set>
                                                         </davinci-drop-down>
                                                     </layout-column>
@@ -55,18 +55,18 @@
                                                             class="myCustomMarginTop7PX_CSK_Module_IODDInterpreter"
                                                             style="justify-content: center; align-items: center">
                                                             <davinci-button id="Button_AddInstance"
-                                                                class="myCustomButton_CSK_Module_IODDInterpreter" type="outline"
-                                                                icon-position="append" title="Add instance"
-                                                                icon="content/add">
+                                                                class="myCustomButton_CSK_Module_IODDInterpreter"
+                                                                type="outline" title="Add instance">
+                                                                <davinci-icon icon="content/add"></davinci-icon>
                                                                 <span></span>
                                                                 <crown-binding event="submit"
                                                                     name="CSK_IODDInterpreter/addInstance" auto-commit>
                                                                 </crown-binding>
                                                             </davinci-button>
                                                             <davinci-button id="B_DeleteInstance"
-                                                                class="myCustomButton_CSK_Module_IODDInterpreter" type="outline"
-                                                                icon-position="append" title="Delete Instance"
-                                                                icon="action/delete">
+                                                                class="myCustomButton_CSK_Module_IODDInterpreter"
+                                                                type="outline" title="Delete Instance">
+                                                                <davinci-icon icon="action/delete"></davinci-icon>
                                                                 <span></span>
                                                                 <crown-set event="submit"
                                                                     crown-function="CSK_IODDInterpreter/deleteInstance"
@@ -79,13 +79,15 @@
                                             </layout-column>
                                         </layout-row>
                                     </layout-column>
-                                    <layout-column id="ColumnLayout8" class="myCustomBorderLeft_CSK_Module_IODDInterpreter"
+                                    <layout-column id="ColumnLayout8"
+                                        class="myCustomBorderLeft_CSK_Module_IODDInterpreter"
                                         style="align-items: stretch">
                                         <layout-row id="RowLayout46" style="align-items: baseline">
                                             <layout-column id="ColumnLayout81" style="align-items: stretch">
                                                 <layout-row id="RowLayout24" style="align-items: center">
                                                     <layout-column id="ColumnLayout57" style="align-items: stretch">
-                                                        <davinci-value-display id="VD_PersistentData" value="Persistent Data">
+                                                        <davinci-value-display id="VD_PersistentData"
+                                                            value="Persistent Data">
                                                         </davinci-value-display>
                                                     </layout-column>
                                                     <layout-column id="ColumnLayout73"
@@ -93,7 +95,8 @@
                                                         <davinci-text-field id="TF_ParameterName" type="text"
                                                             title="Name of the parameters within the CSK_PersistentData module to be uses for this module.">
                                                             <crown-edpws-binding property="value"
-                                                                name="CSK_IODDInterpreter/OnNewParameterName" update-on-resume>
+                                                                name="CSK_IODDInterpreter/OnNewParameterName"
+                                                                update-on-resume>
                                                             </crown-edpws-binding>
                                                             <crown-binding event="change"
                                                                 name="CSK_IODDInterpreter/setParameterName"
@@ -101,21 +104,25 @@
                                                             </crown-binding>
                                                             <crown-edpws-binding property="disabled"
                                                                 name="CSK_IODDInterpreter/OnPersistentDataModuleAvailable"
-                                                                update-on-resume converter="function(value) {return !value;}">
+                                                                update-on-resume
+                                                                converter="function(value) {return !value;}">
                                                             </crown-edpws-binding>
                                                         </davinci-text-field>
                                                     </layout-column>
-                                                    <layout-column id="Column_PersistentData" style="align-items: stretch">
+                                                    <layout-column id="Column_PersistentData"
+                                                        style="align-items: stretch">
                                                         <layout-row id="RowLayout55">
-                                                            <layout-column id="ColumnLayout76" style="align-items: stretch">
+                                                            <layout-column id="ColumnLayout76"
+                                                                style="align-items: stretch">
                                                                 <layout-row id="RowLayout3"
                                                                     class="myCustomMarginTop7PX_CSK_Module_IODDInterpreter"
                                                                     style="justify-content: center; align-items: center">
                                                                     <davinci-button id="B_LoadConfig"
                                                                         class="myCustomButton_CSK_Module_IODDInterpreter"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Load configured parameters from CSK_PersistentData module."
-                                                                        icon="action/history">
+                                                                        type="outline"
+                                                                        title="Load configured parameters from CSK_PersistentData module.">
+                                                                        <davinci-icon icon="action/history">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_IODDInterpreter/loadParameters"
@@ -129,9 +136,10 @@
                                                                     </davinci-button>
                                                                     <davinci-button id="B_SaveConfig"
                                                                         class="myCustomButton_CSK_Module_IODDInterpreter"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Save current configured parameters of this module within CSK_PersistentData module."
-                                                                        icon="content/save">
+                                                                        type="outline"
+                                                                        title="Save current configured parameters of this module within CSK_PersistentData module.">
+                                                                        <davinci-icon icon="content/save">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_IODDInterpreter/sendParameters"
@@ -156,7 +164,8 @@
                                                             <layout-row id="RowLayout45"
                                                                 class="myCustomPersistentDataMarginBack_CSK_Module_IODDInterpreter"
                                                                 style="align-items: center">
-                                                                <layout-column id="ColumnLayout6" style="align-items: stretch">
+                                                                <layout-column id="ColumnLayout6"
+                                                                    style="align-items: stretch">
                                                                 </layout-column>
                                                                 <layout-column id="ColumnLayout72"
                                                                     style="align-items: stretch; flex-grow: 2">
@@ -165,25 +174,29 @@
                                                                             style="align-items: stretch">
                                                                             <layout-row id="RowLayout2"
                                                                                 style="align-items: center">
-                                                                                <davinci-value-display id="VD_LoadConfig"
+                                                                                <davinci-value-display
+                                                                                    id="VD_LoadConfig"
                                                                                     value="Load on reboot:"
                                                                                     title="Load configured parameters from CSK_PersistentData on app start.">
                                                                                 </davinci-value-display>
                                                                                 <davinci-checkbox id="CB_LoadConfig"
                                                                                     title="Load configured parameters from CSK_PersistentData on app start.">
                                                                                     <span></span>
-                                                                                    <crown-edpws-binding property="checked"
+                                                                                    <crown-edpws-binding
+                                                                                        property="checked"
                                                                                         name="CSK_IODDInterpreter/OnNewStatusLoadParameterOnReboot"
                                                                                         update-on-resume>
                                                                                     </crown-edpws-binding>
-                                                                                    <crown-edpws-binding property="disabled"
+                                                                                    <crown-edpws-binding
+                                                                                        property="disabled"
                                                                                         name="CSK_IODDInterpreter/OnPersistentDataModuleAvailable"
                                                                                         update-on-resume
                                                                                         converter="function(value) {return !value;}">
                                                                                     </crown-edpws-binding>
                                                                                     <crown-binding event="change"
                                                                                         name="CSK_IODDInterpreter/setLoadOnReboot"
-                                                                                        path="param/args/status" auto-commit>
+                                                                                        path="param/args/status"
+                                                                                        auto-commit>
                                                                                     </crown-binding>
                                                                                 </davinci-checkbox>
                                                                             </layout-row>
@@ -193,7 +206,8 @@
                                                                         </layout-column>
                                                                     </layout-row>
                                                                 </layout-column>
-                                                                <layout-column id="ColumnLayout79" style="align-items: stretch">
+                                                                <layout-column id="ColumnLayout79"
+                                                                    style="align-items: stretch">
                                                                 </layout-column>
                                                             </layout-row>
                                                         </davinci-collapse>
@@ -219,25 +233,26 @@
                                             style="align-self: flex-start">
                                         </davinci-value-display>
                                         <curie-callout id="DC_IODDUploadStatus">
-                                            <crown-edpws-binding property="type" name="CSK_IODDInterpreter/OnNewCalloutType"
-                                                update-on-resume>
+                                            <crown-edpws-binding property="type"
+                                                name="CSK_IODDInterpreter/OnNewCalloutType" update-on-resume>
                                             </crown-edpws-binding>
-                                            <crown-edpws-binding property="value" name="CSK_IODDInterpreter/OnNewCalloutValue"
-                                                update-on-resume>
+                                            <crown-edpws-binding property="value"
+                                                name="CSK_IODDInterpreter/OnNewCalloutValue" update-on-resume>
                                             </crown-edpws-binding>
                                         </curie-callout>
                                         <layout-row id="RowLayout5">
                                             <layout-column id="ColumnLayout15" style="align-items: stretch">
                                                 <layout-row id="RowLayout8">
                                                     <layout-column id="ColumnLayout85" style="align-items: center">
-                                                        <appspace-file-upload-button id="FUB_IODDUpload" button-type="outline"
-                                                            path="public/tempIODD.xml" is-file icon="file/file_upload"
-                                                            title="Upload IODD XML file">
+                                                        <appspace-file-upload-button id="FUB_IODDUpload"
+                                                            button-type="outline" path="public/tempIODD.xml" is-file
+                                                            icon="file/file_upload" title="Upload IODD XML file">
                                                             <span>Upload IODD</span>
-                                                            <crown-binding event="finished"
-                                                                name="CSK_IODDInterpreter/uploadFinished"
-                                                                path="param/args/uploadSuccess" auto-commit>
-                                                            </crown-binding>
+                                                            <crown-set event="finished"
+                                                                crown-function="CSK_IODDInterpreter/uploadFinished"
+                                                                protocol="crownMSGPACK" crown-path="uploadSuccess"
+                                                                converter="(value)=>{console.log(`event finished ${JSON.stringify(value)}`); return typeof value == 'boolean' ? value : value.success;}">
+                                                            </crown-set>
                                                         </appspace-file-upload-button>
                                                     </layout-column>
                                                     <layout-column id="ColumnLayout10" style="align-items: stretch">
@@ -252,15 +267,16 @@
                                                             </crown-on>
                                                             <crown-set event="change"
                                                                 crown-function="CSK_IODDInterpreter/setSelectedIODDToHandle"
-                                                                protocol="crownMSGPACK" crown-path="newSelectedIODDToHandle">
+                                                                protocol="crownMSGPACK"
+                                                                crown-path="newSelectedIODDToHandle">
                                                             </crown-set>
                                                         </davinci-drop-down>
                                                     </layout-column>
                                                     <layout-column id="ColumnLayout9" style="align-items: center">
                                                         <davinci-button id="B_DeleteIODD"
-                                                            class="myCustomButton_CSK_Module_IODDInterpreter" type="outline"
-                                                            icon-position="append" title="Delete selected IODD File"
-                                                            icon="action/delete">
+                                                            class="myCustomButton_CSK_Module_IODDInterpreter"
+                                                            type="outline" title="Delete selected IODD File">
+                                                            <davinci-icon icon="action/delete"></davinci-icon>
                                                             <span></span>
                                                             <crown-set event="submit"
                                                                 crown-function="CSK_IODDInterpreter/deleteIODD"
@@ -275,8 +291,10 @@
                                                 style="align-items: stretch">
                                                 <stacked-view id="SV_isInstanceSelected">
                                                     <stacked-pane id="SP_instanceISSelected" value="true">
-                                                        <layout-row id="RowLayout7" style="justify-content: space-between">
-                                                            <layout-column id="ColumnLayout7" style="align-items: stretch">
+                                                        <layout-row id="RowLayout7"
+                                                            style="justify-content: space-between">
+                                                            <layout-column id="ColumnLayout7"
+                                                                style="align-items: stretch">
                                                                 <davinci-text-field id="TF_InstanceId" type="text"
                                                                     label="Instance ID">
                                                                     <crown-on property="value"
@@ -284,11 +302,13 @@
                                                                     </crown-on>
                                                                     <crown-set event="change"
                                                                         crown-function="CSK_IODDInterpreter/setInstanceName"
-                                                                        protocol="crownMSGPACK" crown-path="newInstanceName">
+                                                                        protocol="crownMSGPACK"
+                                                                        crown-path="newInstanceName">
                                                                     </crown-set>
                                                                 </davinci-text-field>
                                                             </layout-column>
-                                                            <layout-column id="ColumnLayout11" style="align-items: stretch">
+                                                            <layout-column id="ColumnLayout11"
+                                                                style="align-items: stretch">
                                                                 <davinci-drop-down id="DD_IODDListForInstace"
                                                                     label="Select IODD to be used by instance">
                                                                     <crown-on property="data"
@@ -327,8 +347,8 @@
         					</span>
                         </davinci-callout>
                     </stacked-pane>
-                    <crown-edpws-binding property="value" name="CSK_IODDInterpreter/OnUserLevelOperatorActive" update-on-resume
-                        converter="function(value) {return value.toString();}">
+                    <crown-edpws-binding property="value" name="CSK_IODDInterpreter/OnUserLevelOperatorActive"
+                        update-on-resume converter="function(value) {return value.toString();}">
                     </crown-edpws-binding>
                 </stacked-view>
             </stacked-pane>

--- a/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter.html
+++ b/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter.html
@@ -247,7 +247,7 @@
                                                         <appspace-file-upload-button id="FUB_IODDUpload"
                                                             button-type="outline" path="public/tempIODD.xml" is-file
                                                             icon="file/file_upload" title="Upload IODD XML file">
-                                                            <span>Upload IODD</span>
+                                                            <span>Upload IODD (XML)</span>
                                                             <crown-set event="finished"
                                                                 crown-function="CSK_IODDInterpreter/uploadFinished"
                                                                 protocol="crownMSGPACK" crown-path="uploadSuccess"

--- a/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter_ReadData.html
+++ b/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter_ReadData.html
@@ -1,7 +1,9 @@
 <layout-row id="RowLayout1" class="myCustomBackground_CSK_Module_IODDInterpreter">
     <layout-column id="ColumnLayout1" class="myCustomFrameNoColor_CSK_Module_IODDInterpreter"
         style="align-items: stretch">
-        <h2 id="H2_Title">IODD Read Data</h2>
+        <h1 id="Heading_Title" class="myCustomLabel_CSK_Module_IODDInterpreter">
+            IODD Read Data
+        </h1>
         <stacked-view id="SV_IsInstanceSelected">
             <stacked-pane id="SP_InstanceISSelected" value="true">
                 <layout-row id="RowLayout2" class="myCustomFrame_CSK_Module_IODDInterpreter">

--- a/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter_WriteData.html
+++ b/CSK_Module_IODDInterpreter/pages/pages/CSK_Module_IODDInterpreter/CSK_Module_IODDInterpreter_WriteData.html
@@ -1,7 +1,9 @@
 <layout-row id="RowLayout1" class="myCustomBackground_CSK_Module_IODDInterpreter">
     <layout-column id="ColumnLayout1" class="myCustomFrameNoColor_CSK_Module_IODDInterpreter"
         style="align-items: stretch">
-        <h2 id="H2_Title">IODD Write Data</h2>
+        <h1 id="Heading_Title" class="myCustomLabel_CSK_Module_IODDInterpreter">
+            IODD Write Data
+        </h1>
         <stacked-view id="SV_IsInstanceSelected">
             <stacked-pane id="SP_InstanceIsSelected" value="true">
                 <layout-row id="RowLayout2">

--- a/CSK_Module_IODDInterpreter/pages/src/converter.ts
+++ b/CSK_Module_IODDInterpreter/pages/src/converter.ts
@@ -29,6 +29,14 @@ export function str2num(newstr){
 export function changeStyle(theme) {
   const style: HTMLStyleElement = document.createElement('style');
   style.id ='blub'
+
+  const toggleSW = document.querySelectorAll("davinci-toggle-switch")
+  toggleSW.forEach((userItem) => {
+    const shadowToggle = userItem.shadowRoot
+    const finalToggleSW = shadowToggle?.querySelector('div')
+    finalToggleSW?.classList.add('hasIcon')
+  });
+
   if (theme == 'CSK_Style'){
     var headerToolbar = `.sopasjs-ui-header-toolbar-wrapper { background-color: #FFFFFF; }`
     var uiHeader = `.sopasjs-ui-header>.app-logo { margin-right:0px; }`

--- a/CSK_Module_IODDInterpreter/pages/src/index.ts
+++ b/CSK_Module_IODDInterpreter/pages/src/index.ts
@@ -20,6 +20,10 @@ document.addEventListener('sopasjs-ready', () => {
   page_Setup.remove();
 
   setTimeout(() => {
+    const element = document.querySelector("div.sjs-wrapper > div > div.sjs-fullscreen-toggle")
+    if(element) {
+      element.parentElement.removeChild(element)
+    }
     document.title = 'CSK_Module_IODDInterpreter'
   }, 500);
 })

--- a/CSK_Module_IODDInterpreter/project.mf.xml
+++ b/CSK_Module_IODDInterpreter/project.mf.xml
@@ -475,7 +475,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">2.1.2</meta>
+        <meta key="version">2.1.3</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Model.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Model.lua
@@ -221,10 +221,10 @@ end
 ---@return string newInstanceId Name of the created instance
 local function createNewInstance()
   local instanceNumber = ioddInterpreter_Model.helperFuncs.getTableSize(ioddInterpreter_Model.parameters.instances)
-  local newInstanceId = 'newIntance' .. tostring(instanceNumber)
+  local newInstanceId = 'newInstance' .. tostring(instanceNumber)
   while ioddInterpreter_Model.parameters.instances[newInstanceId] do
     instanceNumber = instanceNumber + 1
-    newInstanceId = 'newIntance' .. tostring(instanceNumber)
+    newInstanceId = 'newInstance' .. tostring(instanceNumber)
   end
   ioddInterpreter_Model.parameters.instances[newInstanceId] = {
     selectedReadParameters = {},

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/helper/xml2lua.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/helper/xml2lua.lua
@@ -412,7 +412,16 @@ local function parseXmlDeclaration(self, xml, f)
     f.match, f.endMatch, f.text = string.find(xml, self._PI, f.pos)
     if not f.match then 
         err(self, self._errstr.declErr, f.pos)
-    end 
+    end
+
+    -- Check for BOM
+    if f.match == 4 then
+      xml = string.sub(xml, 4)
+      f.match, f.endMatch, f.text = string.find(xml, self._PI, f.pos)
+      if not f.match then 
+          err(self, self._errstr.declErr, f.pos)
+      end
+    end
 
     if f.match ~= 1 then
         -- Must be at start of doc if present

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Tested on
 
 |Device|Firmware version|Module version|
 |--|--|--|
-|SICK AppEngine|V1.7.0|V1.1.0|
+|SIM1012|V2.4.2|V2.1.3|
 |SIM1012|V2.4.2|V2.1.1|
 |SIM1012|V2.4.2|V2.1.0|
 |SIM1012|V2.4.2|V1.1.0|
@@ -50,6 +50,7 @@ Tested on
 |SIM1012|v2.3.0|v1.0.0|
 |SIM1012|v2.4.1|v1.0.1|
 |SIM1012|v2.4.1|v1.0.0|
+|SICK AppEngine|V1.7.0|V1.1.0|
 
 This module is part of the SICK AppSpace Coding Starter Kit developing approach.  
 It is programmed in an object-oriented way. Some of the modules use kind of "classes" in Lua to make it possible to reuse code / classes in other projects.  

--- a/docu/CSK_Module_IODDInterpreter.html
+++ b/docu/CSK_Module_IODDInterpreter.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_IODDInterpreter 2.1.2</title>
+<title>Documentation - CSK_Module_IODDInterpreter 2.1.3</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,10 +615,10 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_IODDInterpreter 2.1.2</h1>
+<h1>Documentation - CSK_Module_IODDInterpreter 2.1.3</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 2.1.2,</span>
+<span id="revnumber">version 2.1.3,</span>
 <span id="revdate">2025-01-22</span>
 </div>
 <div id="toc" class="toc2">
@@ -755,7 +755,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2.1.2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2.1.3</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
@@ -5534,7 +5534,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 2.1.2<br>
+Version 2.1.3<br>
 Last updated 2025-01-22 11:40:09 +0100
 </div>
 </div>


### PR DESCRIPTION
# Release 2.1.3

## Improvements
- Check for BOM in XML file

## Bugfix
- Legacy bindings of ValueDisplay elements and FileUpload feature within UI did not work if deployed with VS Code AppSpace SDK
- UI differs if deployed via Appstudio or VS Code AppSpace SDK
- Fullscreen icon of iFrame was visible

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
